### PR TITLE
fix(celestia): commit height serialization as a number

### DIFF
--- a/proto/src/prost/v0_34/tendermint.types.rs
+++ b/proto/src/prost/v0_34/tendermint.types.rs
@@ -205,7 +205,6 @@ pub struct Vote {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Commit {
     #[prost(int64, tag = "1")]
-    #[serde(with = "crate::serializers::from_str")]
     pub height: i64,
     #[prost(int32, tag = "2")]
     pub round: i32,

--- a/proto/src/prost/v0_37/tendermint.types.rs
+++ b/proto/src/prost/v0_37/tendermint.types.rs
@@ -176,7 +176,6 @@ pub struct Vote {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Commit {
     #[prost(int64, tag = "1")]
-    #[serde(with = "crate::serializers::from_str")]
     pub height: i64,
     #[prost(int32, tag = "2")]
     pub round: i32,

--- a/tools/proto-compiler/src/constants.rs
+++ b/tools/proto-compiler/src/constants.rs
@@ -160,7 +160,6 @@ pub static CUSTOM_FIELD_ATTRIBUTES: &[(&str, &str)] = &[
     (".tendermint.types.Data.txs", NULLABLEVECARRAY),
     (".tendermint.types.Data.hash", HEXSTRING),
     (".tendermint.types.EvidenceList.evidence", NULLABLE),
-    (".tendermint.types.Commit.height", QUOTED),
     (".tendermint.types.Commit.signatures", NULLABLE),
     (".tendermint.types.CommitSig.validator_address", HEXSTRING),
     (".tendermint.types.CommitSig.timestamp", OPTIONAL),


### PR DESCRIPTION
Celestia json rpc serializes height as a number
```js
  "commit": {
    "height": 1,
    "round": 0,
    "block_id": {
      "hash": "17F7D5108753C39714DCA67E6A73CE855C6EA9B0071BBD4FFE5D2EF7F3973BFC",
      "parts": {
        "total": 1,
        "hash": "BEEBB79CDA7D0574B65864D3459FAC7F718B82496BD7FE8B6288BF0A98C8EA22"
      }
    },
    "signatures": [
      {
        "block_id_flag": 2,
        "validator_address": "F1F83230835AA69A1AD6EA68C6D894A4106B8E53",
        "timestamp": "2023-06-23T10:40:48.769228056Z",
        "signature": "HNn4c02eCt2+nGuBs55L8f3DAz9cgy9psLFuzhtg2XCWnlkt2V43TX2b54hQNi7C0fepBEteA3GC01aJM/JJCg=="
      }
    ]
  },
```