### PR TITLE
chore: Remove unneeded allocations in serializers

### DIFF
--- a/proto/src/serializers.rs
+++ b/proto/src/serializers.rs
@@ -55,6 +55,7 @@
 
 pub mod allow_null;
 pub mod bytes;
+pub mod cow_str;
 pub mod evidence;
 pub mod from_str;
 pub mod nullable;

--- a/proto/src/serializers/bytes.rs
+++ b/proto/src/serializers/bytes.rs
@@ -6,13 +6,14 @@ pub mod hexstring {
     use subtle_encoding::hex;
 
     use crate::prelude::*;
+    use crate::serializers::cow_str::CowStr;
 
     /// Deserialize a hex-encoded string into `Vec<u8>`
     pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
     where
         D: Deserializer<'de>,
     {
-        let string = Option::<String>::deserialize(deserializer)?.unwrap_or_default();
+        let string = Option::<CowStr>::deserialize(deserializer)?.unwrap_or_default();
         hex::decode_upper(&string)
             .or_else(|_| hex::decode(&string))
             .map_err(serde::de::Error::custom)
@@ -36,6 +37,7 @@ pub mod base64string {
     use subtle_encoding::base64;
 
     use crate::prelude::*;
+    use crate::serializers::cow_str::CowStr;
 
     /// Deserialize base64string into `Vec<u8>`
     pub fn deserialize<'de, D, T>(deserializer: D) -> Result<T, D::Error>
@@ -43,7 +45,7 @@ pub mod base64string {
         D: Deserializer<'de>,
         Vec<u8>: Into<T>,
     {
-        let s = Option::<String>::deserialize(deserializer)?.unwrap_or_default();
+        let s = Option::<CowStr>::deserialize(deserializer)?.unwrap_or_default();
         let v = base64::decode(s).map_err(serde::de::Error::custom)?;
         Ok(v.into())
     }
@@ -53,7 +55,7 @@ pub mod base64string {
     where
         D: Deserializer<'de>,
     {
-        let s = Option::<String>::deserialize(deserializer)?.unwrap_or_default();
+        let s = Option::<CowStr>::deserialize(deserializer)?.unwrap_or_default();
         String::from_utf8(base64::decode(s).map_err(serde::de::Error::custom)?)
             .map_err(serde::de::Error::custom)
     }
@@ -76,13 +78,14 @@ pub mod vec_base64string {
     use subtle_encoding::base64;
 
     use crate::prelude::*;
+    use crate::serializers::cow_str::CowStr;
 
     /// Deserialize array into `Vec<Vec<u8>>`
     pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<Vec<u8>>, D::Error>
     where
         D: Deserializer<'de>,
     {
-        Option::<Vec<String>>::deserialize(deserializer)?
+        Option::<Vec<CowStr>>::deserialize(deserializer)?
             .unwrap_or_default()
             .into_iter()
             .map(|s| base64::decode(s).map_err(serde::de::Error::custom))
@@ -111,13 +114,14 @@ pub mod option_base64string {
     use subtle_encoding::base64;
 
     use crate::prelude::*;
+    use crate::serializers::cow_str::CowStr;
 
     /// Deserialize `Option<base64string>` into `Vec<u8>` or null
     pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
     where
         D: Deserializer<'de>,
     {
-        let s = Option::<String>::deserialize(deserializer)?.unwrap_or_default();
+        let s = Option::<CowStr>::deserialize(deserializer)?.unwrap_or_default();
         base64::decode(s).map_err(serde::de::Error::custom)
     }
 
@@ -135,9 +139,11 @@ pub mod option_base64string {
 
 /// Serialize into string, deserialize from string
 pub mod string {
+    use core::str;
     use serde::{Deserialize, Deserializer, Serializer};
 
     use crate::prelude::*;
+    use crate::serializers::cow_str::CowStr;
 
     /// Deserialize string into `Vec<u8>`
     #[allow(dead_code)]
@@ -145,7 +151,7 @@ pub mod string {
     where
         D: Deserializer<'de>,
     {
-        let string = Option::<String>::deserialize(deserializer)?.unwrap_or_default();
+        let string = Option::<CowStr>::deserialize(deserializer)?.unwrap_or_default();
         Ok(string.as_bytes().to_vec())
     }
 
@@ -156,8 +162,7 @@ pub mod string {
         S: Serializer,
         T: AsRef<[u8]>,
     {
-        let string =
-            String::from_utf8(value.as_ref().to_vec()).map_err(serde::ser::Error::custom)?;
-        serializer.serialize_str(&string)
+        let string = str::from_utf8(value.as_ref()).map_err(serde::ser::Error::custom)?;
+        serializer.serialize_str(string)
     }
 }

--- a/proto/src/serializers/cow_str.rs
+++ b/proto/src/serializers/cow_str.rs
@@ -1,0 +1,39 @@
+use alloc::borrow::Cow;
+use core::fmt::{self, Debug, Display, Formatter};
+use core::ops::Deref;
+use serde::Deserialize;
+
+#[derive(Default, Deserialize)]
+pub struct CowStr<'a>(#[serde(borrow)] Cow<'a, str>);
+
+impl<'a> Debug for CowStr<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        <&str as Debug>::fmt(&&*self.0, f)
+    }
+}
+
+impl<'a> Display for CowStr<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        <&str as Display>::fmt(&&*self.0, f)
+    }
+}
+
+impl<'a> Deref for CowStr<'a> {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'a> AsRef<str> for CowStr<'a> {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl<'a> AsRef<[u8]> for CowStr<'a> {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+}

--- a/proto/src/serializers/from_str.rs
+++ b/proto/src/serializers/from_str.rs
@@ -4,6 +4,7 @@
 use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::prelude::*;
+use crate::serializers::cow_str::CowStr;
 
 /// Deserialize string into T
 pub fn deserialize<'de, D, T>(deserializer: D) -> Result<T, D::Error>
@@ -12,7 +13,7 @@ where
     T: core::str::FromStr,
     <T as core::str::FromStr>::Err: core::fmt::Display,
 {
-    String::deserialize(deserializer)?
+    CowStr::deserialize(deserializer)?
         .parse::<T>()
         .map_err(|e| D::Error::custom(format!("{e}")))
 }

--- a/proto/src/serializers/optional_from_str.rs
+++ b/proto/src/serializers/optional_from_str.rs
@@ -5,6 +5,7 @@ use core::{fmt::Display, str::FromStr};
 use serde::{de::Error, Deserialize, Deserializer, Serializer};
 
 use crate::prelude::*;
+use crate::serializers::cow_str::CowStr;
 
 pub fn serialize<S, T>(value: &Option<T>, serializer: S) -> Result<S::Ok, S::Error>
 where
@@ -23,7 +24,7 @@ where
     T: FromStr,
     T::Err: Display,
 {
-    let s = match Option::<String>::deserialize(deserializer)? {
+    let s = match Option::<CowStr>::deserialize(deserializer)? {
         Some(s) => s,
         None => return Ok(None),
     };

--- a/proto/src/serializers/time_duration.rs
+++ b/proto/src/serializers/time_duration.rs
@@ -4,13 +4,14 @@ use core::time::Duration;
 use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::prelude::*;
+use crate::serializers::cow_str::CowStr;
 
 /// Deserialize string into Duration
 pub fn deserialize<'de, D>(deserializer: D) -> Result<Duration, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let value = String::deserialize(deserializer)?
+    let value = CowStr::deserialize(deserializer)?
         .parse::<u64>()
         .map_err(|e| D::Error::custom(format!("{e}")))?;
 

--- a/proto/src/serializers/timestamp.rs
+++ b/proto/src/serializers/timestamp.rs
@@ -7,6 +7,7 @@ use time::{
     format_description::well_known::Rfc3339 as Rfc3339Format, macros::offset, OffsetDateTime,
 };
 
+use crate::serializers::cow_str::CowStr;
 use crate::{google::protobuf::Timestamp, prelude::*};
 
 /// Helper struct to serialize and deserialize Timestamp into an RFC3339-compatible string
@@ -32,7 +33,7 @@ pub fn deserialize<'de, D>(deserializer: D) -> Result<Timestamp, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let value_string = String::deserialize(deserializer)?;
+    let value_string = CowStr::deserialize(deserializer)?;
     let t = OffsetDateTime::parse(&value_string, &Rfc3339Format).map_err(D::Error::custom)?;
     let t = t.to_offset(offset!(UTC));
     if !matches!(t.year(), 1..=9999) {

--- a/proto/src/serializers/txs.rs
+++ b/proto/src/serializers/txs.rs
@@ -3,13 +3,14 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use subtle_encoding::base64;
 
 use crate::prelude::*;
+use crate::serializers::cow_str::CowStr;
 
 /// Deserialize transactions into `Vec<Vec<u8>>`
 pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<Vec<u8>>, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let value_vec_base64string = Option::<Vec<String>>::deserialize(deserializer)?;
+    let value_vec_base64string = Option::<Vec<CowStr>>::deserialize(deserializer)?;
     if value_vec_base64string.is_none() {
         return Ok(Vec::new());
     }

--- a/tendermint/src/account.rs
+++ b/tendermint/src/account.rs
@@ -13,6 +13,7 @@ use subtle_encoding::hex;
 
 use tendermint_proto::Protobuf;
 
+use crate::serializers::cow_str::CowStr;
 use crate::{error::Error, prelude::*};
 
 /// Size of an  account ID in bytes
@@ -164,7 +165,7 @@ impl<'de> Deserialize<'de> for Id {
     where
         D: Deserializer<'de>,
     {
-        let s = String::deserialize(deserializer)?;
+        let s = CowStr::deserialize(deserializer)?;
         Self::from_str(&s).map_err(|_| {
             de::Error::custom(format!(
                 "expected {}-character hex string, got {:?}",

--- a/tendermint/src/block/height.rs
+++ b/tendermint/src/block/height.rs
@@ -7,6 +7,7 @@ use core::{
 use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
 use tendermint_proto::Protobuf;
 
+use crate::serializers::cow_str::CowStr;
 use crate::{error::Error, prelude::*};
 
 /// Block height for a particular chain (i.e. number of blocks created since
@@ -110,7 +111,7 @@ impl FromStr for Height {
 
 impl<'de> Deserialize<'de> for Height {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        Self::from_str(&String::deserialize(deserializer)?)
+        Self::from_str(&CowStr::deserialize(deserializer)?)
             .map_err(|e| D::Error::custom(format!("{e}")))
     }
 }

--- a/tendermint/src/block/round.rs
+++ b/tendermint/src/block/round.rs
@@ -6,6 +6,7 @@ use core::{
 
 use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
 
+use crate::serializers::cow_str::CowStr;
 use crate::{error::Error, prelude::*};
 
 /// Block round for a particular chain
@@ -91,7 +92,7 @@ impl FromStr for Round {
 
 impl<'de> Deserialize<'de> for Round {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        Self::from_str(&String::deserialize(deserializer)?)
+        Self::from_str(&CowStr::deserialize(deserializer)?)
             .map_err(|e| D::Error::custom(format!("{e}")))
     }
 }

--- a/tendermint/src/chain/id.rs
+++ b/tendermint/src/chain/id.rs
@@ -11,6 +11,7 @@ use core::{
 use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
 use tendermint_proto::Protobuf;
 
+use crate::serializers::cow_str::CowStr;
 use crate::{error::Error, prelude::*};
 
 /// Maximum length of a `chain::Id` name. Matches `MaxChainIDLen` from:
@@ -129,7 +130,7 @@ impl Serialize for Id {
 
 impl<'de> Deserialize<'de> for Id {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        Self::from_str(&String::deserialize(deserializer)?)
+        Self::from_str(&CowStr::deserialize(deserializer)?)
             .map_err(|e| D::Error::custom(format!("{e}")))
     }
 }

--- a/tendermint/src/hash.rs
+++ b/tendermint/src/hash.rs
@@ -11,6 +11,7 @@ use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
 use subtle_encoding::{Encoding, Hex};
 use tendermint_proto::Protobuf;
 
+use crate::serializers::cow_str::CowStr;
 use crate::{error::Error, prelude::*};
 
 /// Output size for the SHA-256 hash function
@@ -166,12 +167,12 @@ impl FromStr for Hash {
 
 impl<'de> Deserialize<'de> for Hash {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let hex = <&str>::deserialize(deserializer)?;
+        let hex = CowStr::deserialize(deserializer)?;
 
         if hex.is_empty() {
             Err(D::Error::custom("empty hash"))
         } else {
-            Ok(Self::from_str(hex).map_err(|e| D::Error::custom(format!("{e}")))?)
+            Ok(Self::from_str(&hex).map_err(|e| D::Error::custom(format!("{e}")))?)
         }
     }
 }

--- a/tendermint/src/node/id.rs
+++ b/tendermint/src/node/id.rs
@@ -9,6 +9,7 @@ use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use subtle::{self, ConstantTimeEq};
 use subtle_encoding::hex;
 
+use crate::serializers::cow_str::CowStr;
 use crate::{error::Error, prelude::*};
 
 /// Length of a Node ID in bytes
@@ -119,7 +120,7 @@ impl<'de> Deserialize<'de> for Id {
     where
         D: Deserializer<'de>,
     {
-        let s = String::deserialize(deserializer)?;
+        let s = CowStr::deserialize(deserializer)?;
         Self::from_str(&s).map_err(|_| {
             de::Error::custom(format!(
                 "expected {}-character hex string, got {:?}",

--- a/tendermint/src/private_key.rs
+++ b/tendermint/src/private_key.rs
@@ -70,8 +70,10 @@ fn deserialize_ed25519_keypair<'de, D>(deserializer: D) -> Result<Ed25519, D::Er
 where
     D: de::Deserializer<'de>,
 {
+    use crate::serializers::cow_str::CowStr;
     use de::Error;
-    let string = Zeroizing::new(String::deserialize(deserializer)?);
+
+    let string = CowStr::deserialize(deserializer)?;
     let mut keypair_bytes = Zeroizing::new([0u8; ED25519_KEYPAIR_SIZE]);
     let decoded_len = Base64::default()
         .decode_to_slice(string.as_bytes(), &mut *keypair_bytes)

--- a/tendermint/src/public_key.rs
+++ b/tendermint/src/public_key.rs
@@ -16,6 +16,7 @@ use serde_json::Value;
 use subtle_encoding::{base64, bech32, hex};
 
 pub use crate::crypto::ed25519::VerificationKey as Ed25519;
+use crate::serializers::cow_str::CowStr;
 use crate::{error::Error, prelude::*};
 
 // Note:On the golang side this is generic in the sense that it could everything that implements
@@ -352,7 +353,7 @@ impl Serialize for Algorithm {
 impl<'de> Deserialize<'de> for Algorithm {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use de::Error;
-        let s = String::deserialize(deserializer)?;
+        let s = CowStr::deserialize(deserializer)?;
         s.parse().map_err(D::Error::custom)
     }
 }
@@ -383,7 +384,7 @@ where
     D: Deserializer<'de>,
 {
     use de::Error;
-    let encoded = String::deserialize(deserializer)?;
+    let encoded = CowStr::deserialize(deserializer)?;
     let bytes = base64::decode(encoded).map_err(D::Error::custom)?;
     Ed25519::try_from(&bytes[..]).map_err(|_| D::Error::custom("invalid Ed25519 key"))
 }
@@ -394,7 +395,7 @@ where
     D: Deserializer<'de>,
 {
     use de::Error;
-    let encoded = String::deserialize(deserializer)?;
+    let encoded = CowStr::deserialize(deserializer)?;
     let bytes = base64::decode(encoded).map_err(D::Error::custom)?;
     Secp256k1::from_sec1_bytes(&bytes).map_err(|_| D::Error::custom("invalid secp256k1 key"))
 }

--- a/tendermint/src/serializers/apphash.rs
+++ b/tendermint/src/serializers/apphash.rs
@@ -3,6 +3,7 @@
 use serde::{Deserialize, Deserializer, Serializer};
 use subtle_encoding::hex;
 
+use crate::serializers::cow_str::CowStr;
 use crate::{prelude::*, AppHash};
 
 /// Deserialize hexstring into AppHash
@@ -10,8 +11,8 @@ pub fn deserialize<'de, D>(deserializer: D) -> Result<AppHash, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let hexstring: String = Option::<String>::deserialize(deserializer)?.unwrap_or_default();
-    AppHash::from_hex_upper(hexstring.as_str()).map_err(serde::de::Error::custom)
+    let hexstring = Option::<CowStr>::deserialize(deserializer)?.unwrap_or_default();
+    AppHash::from_hex_upper(&hexstring).map_err(serde::de::Error::custom)
 }
 
 /// Serialize from AppHash into hexstring

--- a/tendermint/src/serializers/hash.rs
+++ b/tendermint/src/serializers/hash.rs
@@ -3,6 +3,7 @@
 use serde::{Deserialize, Deserializer, Serializer};
 use subtle_encoding::hex;
 
+use crate::serializers::cow_str::CowStr;
 use crate::{hash::Algorithm, prelude::*, Hash};
 
 /// Deserialize hexstring into Hash
@@ -10,8 +11,8 @@ pub fn deserialize<'de, D>(deserializer: D) -> Result<Hash, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let hexstring: String = Option::<String>::deserialize(deserializer)?.unwrap_or_default();
-    Hash::from_hex_upper(Algorithm::Sha256, hexstring.as_str()).map_err(serde::de::Error::custom)
+    let hexstring = Option::<CowStr>::deserialize(deserializer)?.unwrap_or_default();
+    Hash::from_hex_upper(Algorithm::Sha256, &hexstring).map_err(serde::de::Error::custom)
 }
 
 /// Serialize from Hash into hexstring

--- a/tendermint/src/serializers/time.rs
+++ b/tendermint/src/serializers/time.rs
@@ -4,6 +4,7 @@
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+use crate::serializers::cow_str::CowStr;
 use crate::{prelude::*, Time};
 
 /// Serialize from `Time` into `String`
@@ -19,6 +20,6 @@ pub fn deserialize<'de, D>(deserializer: D) -> Result<Time, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let s = String::deserialize(deserializer)?;
+    let s = CowStr::deserialize(deserializer)?;
     Time::parse_from_rfc3339(&s).map_err(serde::de::Error::custom)
 }

--- a/tendermint/src/timeout.rs
+++ b/tendermint/src/timeout.rs
@@ -2,6 +2,7 @@ use core::{fmt, ops::Deref, str::FromStr, time::Duration};
 
 use serde::{de, de::Error as _, ser, Deserialize, Serialize};
 
+use crate::serializers::cow_str::CowStr;
 use crate::{error::Error, prelude::*};
 
 /// Timeout durations
@@ -68,10 +69,10 @@ impl fmt::Display for Timeout {
 impl<'de> Deserialize<'de> for Timeout {
     /// Parse `Timeout` from string ending in `s` or `ms`
     fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let string = String::deserialize(deserializer)?;
+        let string = CowStr::deserialize(deserializer)?;
         string
             .parse()
-            .map_err(|_| D::Error::custom(format!("invalid timeout value: {:?}", &string)))
+            .map_err(|_| D::Error::custom(format!("invalid timeout value: {:?}", string)))
     }
 }
 

--- a/tendermint/src/vote/power.rs
+++ b/tendermint/src/vote/power.rs
@@ -7,6 +7,7 @@ use core::{
 
 use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
 
+use crate::serializers::cow_str::CowStr;
 use crate::{error::Error, prelude::*};
 
 /// Voting power
@@ -82,7 +83,7 @@ impl Power {
 impl<'de> Deserialize<'de> for Power {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         Ok(Power(
-            String::deserialize(deserializer)?
+            CowStr::deserialize(deserializer)?
                 .parse::<i64>()
                 .map_err(|e| D::Error::custom(format!("{e}")))?
                 .try_into()


### PR DESCRIPTION
 This PR reduces the allocations when deserializing in half.

Most of the implemented deserializers was doing a two step deserialization, the first step was to get string value of the field and the second was to convert it to the actual type (i.e. decode base64 to vec). Until now the first step was using `String` which allocates a new string for the value, however it could just borrow it.

The usual way to do this is `<&str>::deserialize(deserializer)` whoever, in the case of JSON this will fail if the borrowed string contains the escape character `\`. Another issue was that `Cow::<str>::deserialize` always allocates.

A solution was to implement the wrapper `CowStr` which wraps `Cow<str>` and uses `#[serde(borrow)]` which can handle the borrowing of the string.