### PR TITLE
feat(proto): allow serialization of Event

### DIFF
--- a/proto/src/prost/v0_34/tendermint.abci.rs
+++ b/proto/src/prost/v0_34/tendermint.abci.rs
@@ -650,6 +650,7 @@ pub struct LastCommitInfo {
 /// Event allows application developers to attach additional information to
 /// ResponseBeginBlock, ResponseEndBlock, ResponseCheckTx and ResponseDeliverTx.
 /// Later, transactions may be queried using these events.
+#[derive(::serde::Deserialize, ::serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Event {
@@ -659,6 +660,7 @@ pub struct Event {
     pub attributes: ::prost::alloc::vec::Vec<EventAttribute>,
 }
 /// EventAttribute is a single key-value pair, associated with an event.
+#[derive(::serde::Deserialize, ::serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EventAttribute {

--- a/proto/src/prost/v0_37/tendermint.abci.rs
+++ b/proto/src/prost/v0_37/tendermint.abci.rs
@@ -634,6 +634,7 @@ pub struct ExtendedCommitInfo {
 /// Event allows application developers to attach additional information to
 /// ResponseBeginBlock, ResponseEndBlock, ResponseCheckTx and ResponseDeliverTx.
 /// Later, transactions may be queried using these events.
+#[derive(::serde::Deserialize, ::serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Event {
@@ -643,6 +644,7 @@ pub struct Event {
     pub attributes: ::prost::alloc::vec::Vec<EventAttribute>,
 }
 /// EventAttribute is a single key-value pair, associated with an event.
+#[derive(::serde::Deserialize, ::serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EventAttribute {

--- a/tools/proto-compiler/src/constants.rs
+++ b/tools/proto-compiler/src/constants.rs
@@ -96,6 +96,8 @@ pub static CUSTOM_TYPE_ATTRIBUTES: &[(&str, &str)] = &[
     (".tendermint.types.ValidatorSet", SERIALIZED),
     (".tendermint.crypto.PublicKey.sum", SERIALIZED),
     (".tendermint.crypto.PublicKey.sum", TYPE_TAG),
+    (".tendermint.abci.Event", SERIALIZED),
+    (".tendermint.abci.EventAttribute", SERIALIZED),
     (".tendermint.abci.ResponseInfo", SERIALIZED),
     (".tendermint.types.CanonicalBlockID", SERIALIZED),
     (".tendermint.types.CanonicalPartSetHeader", SERIALIZED),


### PR DESCRIPTION
This is needed for TxReponse of Cosmos SDK