### PR TITLE
Use instant to get time for wasm32 target

### DIFF
--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -53,10 +53,13 @@ sha2 = { version = "0.10", optional = true, default-features = false }
 k256 = { version = "0.13", optional = true, default-features = false, features = ["alloc", "ecdsa"] }
 ripemd = { version = "0.1.3", optional = true, default-features = false }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+instant = { version = "0.1", features = [ "wasm-bindgen" ], optional = true}
+
 [features]
 default = ["std", "rust-crypto"]
 std = ["flex-error/std", "flex-error/eyre_tracer", "clock"]
-clock = ["time/std"]
+clock = ["time/std", "dep:instant"]
 secp256k1 = ["k256", "ripemd"]
 rust-crypto = ["sha2", "ed25519-consensus"]
 

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -62,6 +62,7 @@ std = ["flex-error/std", "flex-error/eyre_tracer", "clock"]
 clock = ["time/std", "dep:instant"]
 secp256k1 = ["k256", "ripemd"]
 rust-crypto = ["sha2", "ed25519-consensus"]
+wasm-bindgen = ["instant/wasm-bindgen"]
 
 [dev-dependencies]
 k256 = { version = "0.13", default-features = false, features = ["ecdsa"] }

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -54,7 +54,7 @@ k256 = { version = "0.13", optional = true, default-features = false, features =
 ripemd = { version = "0.1.3", optional = true, default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-instant = { version = "0.1", features = [ "wasm-bindgen" ], optional = true}
+instant = { version = "0.1", optional = true}
 
 [features]
 default = ["std", "rust-crypto"]

--- a/tendermint/src/time.rs
+++ b/tendermint/src/time.rs
@@ -8,6 +8,8 @@ use core::{
     time::Duration,
 };
 
+#[cfg(target_arch = "wasm32")]
+use instant::SystemTime;
 use serde::{Deserialize, Serialize};
 use tendermint_proto::{google::protobuf::Timestamp, serializers::timestamp, Protobuf};
 use time::{
@@ -64,9 +66,14 @@ impl From<Time> for Timestamp {
 }
 
 impl Time {
-    #[cfg(any(feature = "clock"))]
+    #[cfg(all(feature = "clock", not(target_arch = "wasm32")))]
     pub fn now() -> Time {
         OffsetDateTime::now_utc().try_into().unwrap()
+    }
+
+    #[cfg(all(feature = "clock", target_arch = "wasm32"))]
+    pub fn now() -> Time {
+        SystemTime::now().try_into().unwrap()
     }
 
     // Internal helper to produce a `Time` value validated with regard to
@@ -178,6 +185,25 @@ impl TryFrom<OffsetDateTime> for Time {
 impl From<Time> for OffsetDateTime {
     fn from(t: Time) -> OffsetDateTime {
         t.0.assume_utc()
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl TryFrom<SystemTime> for Time {
+    type Error = Error;
+
+    fn try_from(t: SystemTime) -> Result<Time, Self::Error> {
+        let since_epoch = t
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map_err(|_| Error::date_out_of_range())?;
+
+        Time::from_unix_timestamp(
+            since_epoch
+                .as_secs()
+                .try_into()
+                .map_err(|_| Error::date_out_of_range())?,
+            since_epoch.subsec_nanos(),
+        )
     }
 }
 


### PR DESCRIPTION
When compiled for wasm32, getting time from standard library causees panic. Use `instant` crate to get time when compiling for wasm32 instead.