### PR TITLE
fix: Use `instant` only in wasm32 and with wasm-bindgen feature

### DIFF
--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -54,12 +54,12 @@ k256 = { version = "0.13", optional = true, default-features = false, features =
 ripemd = { version = "0.1.3", optional = true, default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-instant = { version = "0.1", optional = true}
+instant = { version = "0.1", optional = true }
 
 [features]
 default = ["std", "rust-crypto"]
 std = ["flex-error/std", "flex-error/eyre_tracer", "clock"]
-clock = ["time/std", "dep:instant"]
+clock = ["time/std"]
 secp256k1 = ["k256", "ripemd"]
 rust-crypto = ["sha2", "ed25519-consensus"]
 wasm-bindgen = ["instant/wasm-bindgen"]

--- a/tendermint/src/time.rs
+++ b/tendermint/src/time.rs
@@ -8,7 +8,7 @@ use core::{
     time::Duration,
 };
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "clock", target_arch = "wasm32", feature = "wasm-bindgen"))]
 use instant::SystemTime;
 use serde::{Deserialize, Serialize};
 use tendermint_proto::{google::protobuf::Timestamp, serializers::timestamp, Protobuf};
@@ -71,7 +71,7 @@ impl Time {
         OffsetDateTime::now_utc().try_into().unwrap()
     }
 
-    #[cfg(all(feature = "clock", target_arch = "wasm32"))]
+    #[cfg(all(feature = "clock", target_arch = "wasm32", feature = "wasm-bindgen"))]
     pub fn now() -> Time {
         SystemTime::now().try_into().unwrap()
     }
@@ -188,7 +188,7 @@ impl From<Time> for OffsetDateTime {
     }
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "clock", target_arch = "wasm32", feature = "wasm-bindgen"))]
 impl TryFrom<SystemTime> for Time {
     type Error = Error;
 


### PR DESCRIPTION
Needed by https://github.com/eigerco/celestia-node-rs/pull/143