### PR TITLE
chore: release v0.33.0

### DIFF
--- a/proto/CHANGELOG.md
+++ b/proto/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.33.0](https://github.com/eigerco/celestia-tendermint-rs/compare/celestia-tendermint-proto-v0.32.2...celestia-tendermint-proto-v0.33.0) - 2024-10-31
+- release introduced to mark breaking change of updating prost
 
 ### Other
 

--- a/proto/CHANGELOG.md
+++ b/proto/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.32.3](https://github.com/eigerco/celestia-tendermint-rs/compare/celestia-tendermint-proto-v0.32.2...celestia-tendermint-proto-v0.32.3) - 2024-10-31
+## [0.33.0](https://github.com/eigerco/celestia-tendermint-rs/compare/celestia-tendermint-proto-v0.32.2...celestia-tendermint-proto-v0.33.0) - 2024-10-31
 
 ### Other
 

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "celestia-tendermint-proto"
-version    = "0.32.3"
+version    = "0.33.0"
 edition    = "2021"
 license    = "Apache-2.0"
 homepage   = "https://www.eiger.co"

--- a/tendermint/CHANGELOG.md
+++ b/tendermint/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.33.0](https://github.com/eigerco/celestia-tendermint-rs/compare/celestia-tendermint-v0.32.2...celestia-tendermint-v0.33.0) - 2024-10-31
+- release introduced to mark breaking change of updating prost
 
 ### Other
 

--- a/tendermint/CHANGELOG.md
+++ b/tendermint/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.32.3](https://github.com/eigerco/celestia-tendermint-rs/compare/celestia-tendermint-v0.32.2...celestia-tendermint-v0.32.3) - 2024-10-31
+## [0.33.0](https://github.com/eigerco/celestia-tendermint-rs/compare/celestia-tendermint-v0.32.2...celestia-tendermint-v0.33.0) - 2024-10-31
 
 ### Other
 

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "celestia-tendermint"
-version    = "0.32.3"
+version    = "0.33.0"
 license    = "Apache-2.0"
 homepage   = "https://www.eiger.co"
 repository = "https://github.com/eigerco/celestia-tendermint-rs"
@@ -33,7 +33,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 prost.workspace = true
 prost-types.workspace = true
-celestia-tendermint-proto = { version = "0.32.3", default-features = false, path = "../proto" }
+celestia-tendermint-proto = { version = "0.33.0", default-features = false, path = "../proto" }
 
 bytes = { version = "1.2", default-features = false, features = ["serde"] }
 digest = { version = "0.10", default-features = false }


### PR DESCRIPTION
## 🤖 New release
* `celestia-tendermint-proto`: 0.32.3 -> 0.33.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `celestia-tendermint-proto`
<blockquote>

## [0.33.0](https://github.com/eigerco/celestia-tendermint-rs/compare/celestia-tendermint-proto-v0.32.2...celestia-tendermint-proto-v0.33.0) - 2024-10-31

### Other

- Update prost to 0.13.3 ([#32](https://github.com/eigerco/celestia-tendermint-rs/pull/32))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).